### PR TITLE
Fixed Demo Blog Post Small Typo

### DIFF
--- a/Sources/DesignSite/DesignTheme.swift
+++ b/Sources/DesignSite/DesignTheme.swift
@@ -126,7 +126,7 @@ let demoPostHTML = """
           This site contains Vapor's Design Guide showing examples of different components used in web pages. Evetually, this design guide will be rolled out across all of Vapor's sites, old and new.
         </p>
         <p>
-          The designs have been developed in conjunction with <a href="https://www.redbourbon.co">Red Bourbon</a> who have created some amazing desgins for us. The code for this site, the desgin guide and the reference designs can be found on <a href="https://github.com/vapor/design">GitHub</a>.
+          The designs have been developed in conjunction with <a href="https://www.redbourbon.co">Red Bourbon</a> who have created some amazing designs for us. The code for this site, the design guide and the reference designs can be found on <a href="https://github.com/vapor/design">GitHub</a>.
         </p>
 
         <p>


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
Fixed a Typo on the Demo Blog Post by replacing `desgin` with `design`

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
