### PR TITLE
Add check to avoid running CI on dependabot PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,17 +10,17 @@ jobs:
     name: Run Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18.12.1
-          cache: npm
-      - name: NPM Install
-        run: npm install
-      - name: Setup cloudformation lint
-        uses: ScottBrenner/cfn-lint-action@v2
-      - name: Run cloudformation lint
-        run: cfn-lint -t stack.yaml
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18.12.1
+        cache: npm
+    - name: NPM Install
+      run: npm install
+    - name: Setup cloudformation lint
+      uses: ScottBrenner/cfn-lint-action@v2
+    - name: Run cloudformation lint
+      run: cfn-lint -t stack.yaml
   build:
     if: ${{ github.actor != 'dependabot[bot]' }}
     name: Build and Deploy

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,18 +10,19 @@ jobs:
     name: Run Tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 18.12.1
-        cache: npm
-    - name: NPM Install
-      run: npm install
-    - name: Setup cloudformation lint
-      uses: ScottBrenner/cfn-lint-action@v2
-    - name: Run cloudformation lint
-      run: cfn-lint -t stack.yaml
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.12.1
+          cache: npm
+      - name: NPM Install
+        run: npm install
+      - name: Setup cloudformation lint
+        uses: ScottBrenner/cfn-lint-action@v2
+      - name: Run cloudformation lint
+        run: cfn-lint -t stack.yaml
   build:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     name: Build and Deploy
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
This avoids running CI when dependabot triggered it. We can switch `github.actor` to `github.triggering_actor` if we want to be able to run CI manually in the same PR. Also, this just stops building and deploying, not testing, but we can add it to testing too if we want