### PR TITLE
Add README banners in SVG format for most packages

### DIFF
--- a/static/images/swift61up.svg
+++ b/static/images/swift61up.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="89" height="18" role="img" aria-label="swift: 6.0+">
-<title>swift: 6.0+</title>
+<title>swift: 6.1+</title>
 <linearGradient id="s" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -29,8 +29,8 @@
     "/>
   </svg>
   <text aria-hidden="true" x="355" y="140" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="250">swift</text>
-  <text aria-hidden="true" x="695" y="140" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">6.0+</text>
+  <text aria-hidden="true" x="695" y="140" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">6.1+</text>
   <text x="355" y="130" transform="scale(.1)" fill="#fff" textLength="250">swift</text>
-  <text x="695" y="130" transform="scale(.1)" fill="#fff" textLength="270">6.0+</text>
+  <text x="695" y="130" transform="scale(.1)" fill="#fff" textLength="270">6.1+</text>
 </g>
 </svg>

--- a/static/images/swift62up.svg
+++ b/static/images/swift62up.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="89" height="18" role="img" aria-label="swift: 6.0+">
-<title>swift: 6.0+</title>
+<title>swift: 6.2+</title>
 <linearGradient id="s" x2="0" y2="100%">
   <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
   <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -29,8 +29,8 @@
     "/>
   </svg>
   <text aria-hidden="true" x="355" y="140" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="250">swift</text>
-  <text aria-hidden="true" x="695" y="140" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">6.0+</text>
+  <text aria-hidden="true" x="695" y="140" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">6.2+</text>
   <text x="355" y="130" transform="scale(.1)" fill="#fff" textLength="250">swift</text>
-  <text x="695" y="130" transform="scale(.1)" fill="#fff" textLength="270">6.0+</text>
+  <text x="695" y="130" transform="scale(.1)" fill="#fff" textLength="270">6.2+</text>
 </g>
 </svg>

--- a/static/images/vapor-consolekit.svg
+++ b/static/images/vapor-consolekit.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 625 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @font-face { font-family: AvenirN; font-weight: 900; src: local("Avenir Next Bold"); }
+    @font-face { font-family: AvenirN; font-weight: 400; src: local("Avenir Next Medium"); }
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m38.2,45.3c-2.2,1.9-2.3,5-.1,6.9l16.2,14.3c2.2,1.9,5.8,2,8.1.1l26.3-22c2.2-1.9,2.3-5,.1-6.9l-16.2-14.3c-2.2-1.9-5.8-2-8.1-.1zm22.2,11.7c-.7,2.2-4,1.4-3.6-.5l1.4-8.2-9.6,1c-2.2.3-3-2.9-.5-3.1l11.9-1.2c1.1-.2,2.2.7,2,1.8zm17.1-13-7.5,6.3c-1.6,1.4-4.3-1-2.6-2.3l7.5-6.3c1.6-1.4,4.3,1,2.6,2.3z"/>
+  <text id="name" letter-spacing="-4"><tspan font-weight="900">Console</tspan><tspan dx="0">Kit</tspan></text>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+  <use href="#name" x="137" y="99" style="fill: var(--color-logo-base, #000000); font-family: AvenirN, Arial; font-size: 100px;"/>
+</svg>
+

--- a/static/images/vapor-fluent.svg
+++ b/static/images/vapor-fluent.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 429 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @font-face { font-family: AvenirN; font-weight: 900; src: local("Avenir Next Bold"); }
+    @font-face { font-family: AvenirN; font-weight: 400; src: local("Avenir Next Medium"); }
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m83.2,37.9-13.4,2.8,3.6-10.6c1.6-4.7-7.6-6.7-9.2-2l-3.6,10.6-9.8-7.8c-4.3-3.5-11.1,1.8-6.7,5.3l9.8,7.8-13.4,2.8c-6,1.3-3.5,8.5,2.4,7.3l13.4-2.8-3.6,10.6c-1.5,4.5,7.2,6.9,9.2,2l3.6-10.6,9.8,7.8c4.3,3.5,11.1-1.8,6.7-5.3l-9.8-7.8,13.4-2.8c6-1.3,3.5-8.5-2.4-7.2z"/>
+  <text id="name" letter-spacing="-4"><tspan font-weight="900">Fluent</tspan></text>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+  <use href="#name" x="137" y="99" style="fill: var(--color-logo-base, #000000); font-family: AvenirN, Arial; font-size: 100px;"/>
+</svg>
+

--- a/static/images/vapor-fluentkit.svg
+++ b/static/images/vapor-fluentkit.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 545 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @font-face { font-family: AvenirN; font-weight: 900; src: local("Avenir Next Bold"); }
+    @font-face { font-family: AvenirN; font-weight: 400; src: local("Avenir Next Medium"); }
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m73.1,23.8c-.8,0-1.7.3-2.4.9l-9.1,7.3-3.9-3.1c-.7-.6-1.9-.6-2.6,0l-12.3,9.7c-.7.6-.8,1.5-.1,2.1l3.9,3.1-9.6,7.6c-1.6,1.2-1.8,2.6-.6,3.5l2.3,1.8,38.7-30.6-2.1-1.7c-.5-.5-1.3-.7-2.2-.6zm6.2,3.8-38.8,30.7,16.5,13.2c1,.8,2.3.9,3.5-.1l35.2-27.9c1.3-1,.8-2.1.1-2.7zm-22.9,4.4,2.5,2-9.7,7.7-2.6-2zm12.8,11.1.7,4.4,4.2-3.5c1.9-1.5,4.1.5,2.2,2.1l-4.2,3.5,4.9.9c2.2.4.8,3.5-1.3,3.1l-4.9-.9.7,4.4c.2,2.1-3.3,2.9-3.6,1l-.7-4.4-4.2,3.5c-1.9,1.5-4.1-.6-2.2-2.1l4.2-3.5-4.9-.9c-2.2-.4-.8-3.6,1.3-3.1l4.9.9-.7-4.4c-.3-2,3.3-3,3.6-1z"/>
+  <text id="name" letter-spacing="-4"><tspan font-weight="900">Fluent</tspan><tspan dx="3">Kit</tspan></text>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+  <use href="#name" x="137" y="99" style="fill: var(--color-logo-base, #000000); font-family: AvenirN, Arial; font-size: 100px;"/>
+</svg>
+

--- a/static/images/vapor-fluentmysqldriver.svg
+++ b/static/images/vapor-fluentmysqldriver.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 735 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @font-face { font-family: AvenirN; font-weight: 900; src: local("Avenir Next Bold"); }
+    @font-face { font-family: AvenirN; font-weight: 400; src: local("Avenir Next Medium"); }
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m61.7,22c-3-.1-6.6,2-6.2,5.6l2,12-13.3-2.5c-6-1.2-9.8,7.3-3.8,8.5l13.3,2.4-11.4,9.5c-5,4.3,1,9.9,6,5.7l11.4-9.5,1.9,12c.9,5.3,10.7,2.6,9.8-2.8l-1.9-11.9,13.3,2.4c5.9,1.2,9.7-7.3,3.8-8.4l-13.4-2.5,11.4-9.5c5.1-4.2-1-9.8-6-5.7l-11.4,9.5-1.9-12c-.3-1.9-1.8-2.8-3.6-2.8zm6,16.7c1.9,0,3,1.1,3,1.1.1.1.2,0,.2.1,1.5-.1,1.7.1,1.8.2,0,0-.1.1-.2.2-1.1,1.1-3.3,1.5-5.5,3.4-.1-.2.1-.5,0-.8-.2,0-.4,0-.6,0,.1,1,.1,3.3-.3,3.6-.4-.1-.8-1.7-1.1-.7-.2.1-.4.2-.5.3.1.4.3.7.5,1-2.2,3.1-2.5,6.3-2.5,6.5,0,0,.5,1.3,2.6,2-.4.3-.9.6-1.4.7l-.1-1.1c-.3-.2-.3.5-1,1.8-.3-1.1-.6-2.4-1-3.5-2.5-4.5-1.1-9.1-.9-9.5-.7-.5-1.5-.4-2.3-.2,1.1-2,2.8-2.8,4.1-2.9.2.1.1,0,1-.7,1.6-1.2,3.1-1.5,4.2-1.5zm1,.7c-.4,0-.8.5-.4.9.5.5,1.2-.3.7-.7-.1-.1-.2-.2-.3-.2z"/>
+  <text id="name" letter-spacing="-5"><tspan font-weight="900">Fluent</tspan><tspan dx="2">MySQL</tspan></text>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+  <use href="#name" x="137" y="99" style="fill: var(--color-logo-base, #000000); font-family: AvenirN, Arial; font-size: 100px;"/>
+</svg>
+

--- a/static/images/vapor-fluentpostgresdriver.svg
+++ b/static/images/vapor-fluentpostgresdriver.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 783 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @font-face { font-family: AvenirN; font-weight: 900; src: local("Avenir Next Bold"); }
+    @font-face { font-family: AvenirN; font-weight: 400; src: local("Avenir Next Medium"); }
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m61.7,22c-3-.1-6.6,2-6.2,5.6l2,12-13.3-2.5c-6-1.2-9.8,7.3-3.8,8.5l13.3,2.4-11.4,9.5c-5,4.3,1,9.9,6,5.7l11.4-9.5,1.9,12c.9,5.3,10.7,2.6,9.8-2.8l-1.9-11.9,13.3,2.4c5.9,1.2,9.7-7.3,3.8-8.4l-13.4-2.5,11.4-9.5c5.1-4.2-1-9.8-6-5.7l-11.4,9.5-1.9-12c-.3-1.9-1.8-2.8-3.6-2.8zm2.2,11.9c-.1.2,0,.3.4.3-.9.5-1.3.9-1,1.3,1,.8,2.9-.1,4,2.8.1.4.4-.5.5-1.6.2.2.4.6.3,1.2,0,0,.6-1.9.6-1.9,1.3,2.1-.8,3.2-1.6,4.5-2.3,3.8,2,6,2.7,5.9,1.5.5.2,1.3,1.6,1.8.2.2-.3.6-1.6,1,.1.3.3.4.4.3,2.3.6.3,1.2-.5,1.3-.4-.2-.7-.5-.9-1-.8-.7-1.8-1.5-3-2.2-.7.2-1.4.8-1.9,1.8.8.5,1.5,1.1,2,1.7,1.1.1,1.4.3,1,.7-.5.3-.9.6-1.4.8-.3.1-1-.5-2.2-1.5.6.7,1.1,1.5,1.5,2.4,2,0,.3,1.3.1,1.4-.5.4-.9.3-1.3-.1-.9-1.9-4.5-3.4-5.2-3.6.3.2.6,1.2.5,1.7-.1-.7-.5-1.3-.9-1.9-.3-.6-2.4-4,3.8-6.8,1.1-.4-3.2-.8.8-3.1,0-.6.9-1.4,2.8-2.3.6-1.8-1.5-2-2.5-2.8-.4-.3-.5-1.2.8-1.9,0,0,.1-.2.2-.2zm3.6,13.1c.4.5.8.8.9,1,.3-.3-.1-.7-.9-1z"/>
+  <text id="name" letter-spacing="-5"><tspan font-weight="900">Fluent</tspan><tspan dx="2">Postgres</tspan></text>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+  <use href="#name" x="137" y="99" style="fill: var(--color-logo-base, #000000); font-family: AvenirN, Arial; font-size: 100px;"/>
+</svg>
+

--- a/static/images/vapor-fluentsqlitedriver.svg
+++ b/static/images/vapor-fluentsqlitedriver.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 705 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @font-face { font-family: AvenirN; font-weight: 900; src: local("Avenir Next Bold"); }
+    @font-face { font-family: AvenirN; font-weight: 400; src: local("Avenir Next Medium"); }
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m61.7,22c-3-.1-6.6,2-6.2,5.6l2,12-13.3-2.5c-6-1.2-9.8,7.3-3.8,8.5l13.3,2.4-11.4,9.5c-5,4.3,1,9.9,6,5.7l11.4-9.5,1.9,12c.9,5.3,10.7,2.6,9.8-2.8l-1.9-11.9,13.3,2.4c5.9,1.2,9.7-7.3,3.8-8.4l-13.4-2.5,11.4-9.5c5.1-4.2-1-9.8-6-5.7l-11.4,9.5-1.9-12c-.3-1.9-1.8-2.8-3.6-2.8zm-.4,14.1c.1,0,.2.1.2.2.2.6.8,1.5.8,1.6.2.4.8,1,.9,1.1.5.7-.7,2.6-.7,2.6l1.5-1.4c2.1,2.9,2,5.5,1.7,7.4-.3,1.2-.7,2.3-.6,2.4.3.9.7,1.9,1,2.8l1.1-1.2c2.4-2.1,4.3-4.6,6.4-7-.1.1-2.5,3.6-4.7,6.2c-1,1.1-1.7,1.8-2.5,2.2-.2.2-.4.1-.4.1-1.7-1.6-3-3.5-3.9-5.6-2.7-5.5-1.3-8.4-1.5-8.4-.9,2.2-.7,4.6-.1,6.9.5,1.6,1.3,3,2.3,4.4.1.2-.1.2-.2.2-1-.4-1.9-1-2.6-1.7-4.4-4.3-1.8-9-1-10.3.6,-1,1.6-1.9,2.1-2.4.1,0,.1,0,.2-.1z"/>
+  <text id="name" letter-spacing="-5"><tspan font-weight="900">Fluent</tspan><tspan dx="6">SQLite</tspan></text>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+  <use href="#name" x="137" y="99" style="fill: var(--color-logo-base, #000000); font-family: AvenirN, Arial; font-size: 100px;"/>
+</svg>
+

--- a/static/images/vapor-jwt.svg
+++ b/static/images/vapor-jwt.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 356 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @font-face { font-family: AvenirN; font-weight: 900; src: local("Avenir Next Bold"); }
+    @font-face { font-family: AvenirN; font-weight: 400; src: local("Avenir Next Medium"); }
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m56.8,22.3,1.8,12.8,4.9,4.1,3.6-5.3-1.8-12.8zm10.4,11.6.8,5.4,8.2-3.8,5.8-8.6-7.3-4.2zm9,1.6-4.6,6.8,6.8,1,11.4-5.2-3.7-7.1zm2.1,7.9-6.2,2.9,6.4,5.3,10.7,1.6,1.6-7.9zm.1,8.1-8.9-1.4.8,5.4,10.3,8.6,5.8-6zm-8.2,4-4.9-4.1-3.6,5.3,1.8,12.8,8.6-1.2zm-8.6,1.2-.8-5.4-8.2,3.8-5.8,8.6,7.3,4.2zm-8.9-1.6,4.6-6.8-6.8-1-11.4,5.2,3.7,7.1zm-2.1-7.9,6.2-2.9-6.4-5.3-10.6-1.6-1.6,7.9zm-.1-8.1,8.9,1.4-.8-5.4-10.3-8.6-5.8,6z"/>
+  <text id="name" letter-spacing="0"><tspan font-weight="900">JWT</tspan></text>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+  <use href="#name" x="137" y="99" style="fill: var(--color-logo-base, #000000); font-family: AvenirN, Arial; font-size: 100px;"/>
+</svg>
+

--- a/static/images/vapor-jwtkit.svg
+++ b/static/images/vapor-jwtkit.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 470 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @font-face { font-family: AvenirN; font-weight: 900; src: local("Avenir Next Bold"); }
+    @font-face { font-family: AvenirN; font-weight: 400; src: local("Avenir Next Medium"); }
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m56.8,22.3,1.8,12.8,4.9,4.1,3.6-5.3-1.8-12.8zm10.4,11.6.8,5.4,8.2-3.8,5.8-8.6-7.3-4.2zm9,1.6-4.6,6.8,6.8,1,11.4-5.2-3.7-7.1zm2.1,7.9-6.2,2.9,6.4,5.3,10.7,1.6,1.6-7.9zm.1,8.1-8.9-1.4.8,5.4,10.3,8.6,5.8-6zm-8.2,4-4.9-4.1-3.6,5.3,1.8,12.8,8.6-1.2zm-8.6,1.2-.8-5.4-8.2,3.8-5.8,8.6,7.3,4.2zm-8.9-1.6,4.6-6.8-6.8-1-11.4,5.2,3.7,7.1zm-2.1-7.9,6.2-2.9-6.4-5.3-10.6-1.6-1.6,7.9zm-.1-8.1,8.9,1.4-.8-5.4-10.3-8.6-5.8,6z"/>
+  <text id="name"><tspan font-weight="900">JWT</tspan><tspan letter-spacing="-5" dx="0">Kit</tspan></text>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+  <use href="#name" x="137" y="99" style="fill: var(--color-logo-base, #000000); font-family: AvenirN, Arial; font-size: 100px;"/>
+</svg>
+

--- a/static/images/vapor-leaf.svg
+++ b/static/images/vapor-leaf.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 338 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @font-face { font-family: AvenirN; font-weight: 900; src: local("Avenir Next Bold"); }
+    @font-face { font-family: AvenirN; font-weight: 400; src: local("Avenir Next Medium"); }
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m42.1,52.9c16.7,23.4,55,2.5,44.1-22.8-8.4,16.9-38-1.6-44.2,16.7-2.9-2.1-5.4-4.4-7.7-7l-1,1.4c7.5,8.9,17.6,13.5,35.2,10.7-7.1,4.6-16.6,3.1-26.4.9z"/>
+  <text id="name" letter-spacing="-4"><tspan font-weight="900">Leaf</tspan></text>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+  <use href="#name" x="137" y="99" style="fill: var(--color-logo-base, #000000); font-family: AvenirN, Arial; font-size: 100px;"/>
+</svg>
+

--- a/static/images/vapor-leafkit.svg
+++ b/static/images/vapor-leafkit.svg
@@ -1,0 +1,29 @@
+<svg viewBox="0 0 463 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @font-face { font-family: AvenirN; font-weight: 900; src: local("Avenir Next Bold"); }
+    @font-face { font-family: AvenirN; font-weight: 400; src: local("Avenir Next Medium"); }
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m 73.8,23.8 c -0.2,0 -0.4,0 -0.7,0 -0.8,0 -1.7,0.3 -2.4,0.9 l -9.1,7.3 -3.9,-3.1 c -0.7,-0.6 -1.9,-0.6 -2.6,0 l -12.3,9.7 c -0.7,0.6 -0.8,1.5 -0.1,2.1 l 3.9,3.1 -9.6,7.6 c -1.6,1.2 -1.8,2.6 -0.6,3.5 l 2.3,1.8 38.7,-30.6 -2.1,-1.7 c -0.4,-0.4 -0.9,-0.6 -1.6,-0.6 z m 5.5,3.8 -38.8,30.7 16.5,13.2 c 1,0.8 2.3,0.9 3.5,-0.1 l 35.2,-27.9 c 1.3,-1 0.8,-2.1 0.1,-2.7 z m -22.9,4.4 2.5,2 -9.7,7.7 -2.6,-2 z m 16.7,6.2 c 9.5,7.9 -1.6,24.1 -13,18.1 c 4.4,-1.1 8.5,-2.5 10.4,-5.8 -6.5,4.7 -11.5,4.9 -16.3,2.9 l 0.1,-0.8 c 1.4,0.6 2.9,1 4.5,1.2 -1.2,-8.6 14.4,-7.2 14.3,-15.7 z" />
+  <text id="name" letter-spacing="-2"><tspan font-weight="900">Leaf</tspan><tspan dx="3">Kit</tspan></text>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+  <use href="#name" x="137" y="99" style="fill: var(--color-logo-base, #000000); font-family: AvenirN, Arial; font-size: 100px;"/>
+</svg>

--- a/static/images/vapor-multipartkit.svg
+++ b/static/images/vapor-multipartkit.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 665 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @font-face { font-family: AvenirN; font-weight: 900; src: local("Avenir Next Bold"); }
+    @font-face { font-family: AvenirN; font-weight: 400; src: local("Avenir Next Medium"); }
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m 47,31 c 0,0 2.6,21.9 7.7,26.6 7.5,7 17.5,7 23.9,1.9 6.5,-5.1 7.3,-13.9 -0.7,-20.9 -5.5,-4.8 -30.9,-7.7 -30.9,-7.7 z"/>
+  <text id="name" letter-spacing="-5"><tspan font-weight="900">Multipart</tspan><tspan dx="2">Kit</tspan></text>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+  <use href="#name" x="137" y="99" style="fill: var(--color-logo-base, #000000); font-family: AvenirN, Arial; font-size: 100px;"/>
+</svg>
+

--- a/static/images/vapor-mysqlkit.svg
+++ b/static/images/vapor-mysqlkit.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 590 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @font-face { font-family: AvenirN; font-weight: 900; src: local("Avenir Next Bold"); }
+    @font-face { font-family: AvenirN; font-weight: 400; src: local("Avenir Next Medium"); }
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m70.7,24.7-9.1,7.3-3.9-3.1c-.7-.6-1.9-.6-2.6,0l-12.3,9.7c-.7.6-.8,1.5-.1,2.1l3.9,3.1-9.6,7.6c-1.6,1.2-1.8,2.6-.6,3.5l2.3,1.8,38.7-30.6-2.1-1.7c-1.1-.9-3.2-.9-4.6.3zm8.6,2.9-38.8,30.7,16.5,13.2c1,.8,2.3.9,3.5-.1l35.2-27.9c1.3-1,.8-2.1.1-2.7zm-22.9,4.4,2.5,2-9.7,7.7-2.6-2zm15.4,8.5c2.5-.1,4,1.4,4,1.4.1.2.2.1.3.1,1.8,0,2.1.2,2.2.3l-.3.3c-1.4,1.3-4.1,1.7-6.9,4.1,0-.3,0-.7-.1-1h-.6c.1,1.2,0,4-.5,4.4-.5-.1-1-2.1-1.4-.8l-.6.3c.2.5.4.9.6,1.2-2.8,3.9-3.2,7.8-3.2,8,0,.1.6,1.7,3.1,2.6-.4.3-1.1.7-1.7.8v-1.4c-.4-.1-.4.7-1.4,2.3-.3-1.4-.6-3-1.1-4.4-3-5.7-1.1-11.3-.9-11.8-.9-.6-1.9-.6-2.9-.3,1.5-2.5,3.6-3.4,5.2-3.5.2.1.2,0,1.2-.8,1.9-1.3,3.6-1.8,5-1.8zm1.5.9c-.5,0-1,.6-.5,1.1.6.6,1.5-.3.9-.9-.1-.1-.3-.2-.4-.2z"/>
+  <text id="name" letter-spacing="-4"><tspan font-weight="900">MySQL</tspan><tspan dx="2">Kit</tspan></text>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+  <use href="#name" x="137" y="99" style="fill: var(--color-logo-base, #000000); font-family: AvenirN, Arial; font-size: 100px;"/>
+</svg>
+

--- a/static/images/vapor-mysqlnio.svg
+++ b/static/images/vapor-mysqlnio.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 644 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @font-face { font-family: AvenirN; font-weight: 900; src: local("Avenir Next Bold"); }
+    @font-face { font-family: AvenirN; font-weight: 400; src: local("Avenir Next Medium"); }
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m59.5,70.3c-.7-.2-.7,1.6-3,5.2-.8-3.3-1.5-6.8-2.5-10-6.8-13-2.6-25.7-2.1-27-2.1-1.3-4.3-1.2-6.6-.6,3.3-5.6,8.1-7.7,11.9-7.9.4.2.3-.2,2.7-1.9,12.7-8.8,20.4-1,20.5-.9.1.4.4.2.6.3,4.1-.1,4.8.4,5,.6-.1.1-.2.3-.6.7-3.2,3-9.3,3.9-15.8,9.4,0-.8,0-1.7-.1-2.4-.5,0-1,.1-1.5.1.2,2.6.1,9.1-1,10-1.2-.2-2.3-4.9-3.3-1.9-.5.2-.9.5-1.4.7.5,1.1,1,2,1.4,2.8-6.4,8.8-7.2,17.8-7.2,18.2-.1.2,1.2,3.8,7,5.8-1,.8-2.5,1.7-3.9,1.9zm16.1-43.8c-1.2-1.4-3.5.5-2.2,2,1.4,1.4,3.5-.7,2.2-2z"/>
+  <text id="name" letter-spacing="-5"><tspan font-weight="900">MySQL</tspan><tspan dx="2">NIO</tspan></text>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+  <use href="#name" x="137" y="99" style="fill: var(--color-logo-base, #000000); font-family: AvenirN, Arial; font-size: 100px;"/>
+</svg>
+

--- a/static/images/vapor-postgreskit.svg
+++ b/static/images/vapor-postgreskit.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 650 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @font-face { font-family: AvenirN; font-weight: 900; src: local("Avenir Next Bold"); }
+    @font-face { font-family: AvenirN; font-weight: 400; src: local("Avenir Next Medium"); }
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m70.7,24.8-9.1,7.2-3.9-3.1c-.7-.6-1.9-.6-2.6,0l-12.3,9.7c-.7.6-.8,1.5-.1,2.1l3.9,3.1-9.6,7.6c-1.6,1.2-1.8,2.6-.6,3.5l2.3,1.8,38.7-30.6-2.1-1.7c-1.2-1-3.2-.8-4.6.3zm8.6,2.8-38.8,30.7,16.5,13.2c1,.8,2.3.9,3.5-.1l35.2-27.9c1.3-1,.8-2.1.1-2.7zm-22.9,4.4,2.5,2-9.7,7.7-2.6-2zm12.3,7.1c-.2.2,0,.3.3.3-.8.5-1.2.9-.9,1.2,1,.9,2.9-.1,4,3,.2.3.4-.5.6-1.7.2.2.3.6.3,1.3,0,0,.6-2,.7-2,1.2,2.2-.9,3.3-1.7,4.6-2.4,3.8,2,6.2,2.7,6.1,1.6.5.2,1.3,1.6,1.8.3.2-.2.6-1.6,1,.1.3.3.4.4.3,2.3.7.3,1.2-.5,1.4-.4-.2-.7-.5-.9-1-.8-.8-1.8-1.5-3.1-2.3-.7.2-1.4.8-2,1.8.8.5,1.5,1.2,2.1,1.7,1.1.1,1.4.3,1,.7-.4.4-.9.7-1.4.9-.3.1-1.1-.5-2.2-1.6.5.7,1,1.5,1.4,2.5,2.1,0,.3,1.3.1,1.4-.5.4-.9.4-1.3-.1-.9-1.9-4.6-3.4-5.3-3.7.3.2.6,1.3.5,1.8-.1-.8-.5-1.4-.9-2-.3-.6-2.4-4.1,4-7,1.1-.3-3.3-.7.8-3.1,0-.7.9-1.5,2.9-2.4.6-1.8-1.5-2-2.6-2.8-.3-.4-.5-1.3.9-2,0,0,0-.2.1-.2zm3.6,13.4c.5.4.8.8,1,1,.2-.3-.1-.7-1-1z"/>
+  <text id="name" letter-spacing="-4"><tspan font-weight="900">Postgres</tspan><tspan dx="0">Kit</tspan></text>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+  <use href="#name" x="137" y="99" style="fill: var(--color-logo-base, #000000); font-family: AvenirN, Arial; font-size: 100px;"/>
+</svg>
+

--- a/static/images/vapor-postgresnio.svg
+++ b/static/images/vapor-postgresnio.svg
@@ -1,0 +1,29 @@
+<svg viewBox="0 0 712 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @font-face { font-family: AvenirN; font-weight: 900; src: local("Avenir Next Bold"); }
+    @font-face { font-family: AvenirN; font-weight: 400; src: local("Avenir Next Medium"); }
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m61.2,12.4c-.3.6.1.9,1.2.9-2.6,1.4-3.6,2.6-2.7,3.6,2.7,2.6,8.3-.2,11.5,8.5.5,1,1.2-1.5,1.5-4.9.8.5,1.1,1.7,1,3.7,0,0,1.7-5.8,1.8-5.6,3.6,6.2-2.3,9.3-4.7,13.1-6.8,11.1,5.8,17.7,7.8,17.4,4.5,1.5.6,3.9,4.6,5.2.8.7-.7,1.7-4.5,3,.3.8.7,1,1,.8,6.8,1.9,1.1,3.5-1.4,3.8-1.1-.4-2-1.4-2.6-2.9-2.3-2.1-5.2-4.3-8.9-6.4-2.1.6-3.9,2.3-5.6,5.2,2.4,1.6,4.4,3.3,6.1,5,3,.2,3.9.8,2.7,2-1.2,1.1-2.5,1.9-3.9,2.6-.9.1-3.1-1.6-6.4-4.5,1.6,1.9,3,4.3,4.2,7,5.9,0,.9,3.7.3,4-1.5,1.2-2.7,1.1-3.7-.2-2.6-5.5-13.4-9.8-15.2-10.5.7.6,1.7,3.6,1.4,5.1-.4-2.2-1.4-4-2.7-5.8-1-1.6-7-11.6,11.2-20,3.3-1-9.4-2.1,2.2-9,.1-1.8,2.6-4.1,8.3-6.8,1.9-5.1-4.4-5.7-7.3-8.1-1.1-1-1.5-3.7,2.4-5.7,0,0,.1-.5.4-.5zm13.4,41.3c.7-.9-.2-1.9-2.8-2.8,1.4,1.3,2.4,2.2,2.8,2.8z"/>
+  <text id="name" letter-spacing="-4"><tspan font-weight="900">Postgres</tspan><tspan dx="0">NIO</tspan></text>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+  <use href="#name" x="137" y="99" style="fill: var(--color-logo-base, #000000); font-family: AvenirN, Arial; font-size: 100px;"/>
+</svg>

--- a/static/images/vapor-queues.svg
+++ b/static/images/vapor-queues.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 491 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @font-face { font-family: AvenirN; font-weight: 900; src: local("Avenir Next Bold"); }
+    @font-face { font-family: AvenirN; font-weight: 400; src: local("Avenir Next Medium"); }
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m52.3,31.9l4.3-3.6,3.6,3.2c2.1,1.9,5.7.9,6.5-1.4.5-1.2.2-2.5-.8-3.4l-3.6-3.2,2.8-2.3c1.6-1.3,3.9-1.3,5.3.1l24.8,22.2c1.5,1.3,1.4,3.3-.2,4.6l-29.5,24.6c-1.4,1.2-3.8,1.2-5.2-.1l-14.4-12.9c1.5.1,3.1-.1,4.7-.6l11.8,10.6c.7.6,1.7.5,2.3,0l26.9-22.5c.6-.5.7-1.4.1-2l-17.4-15.6c-.7-.6-1.7-.5-2.3,0l-11,9.2c-.8-1.3-1.6-2.5-2.9-3.6-1.7-1.5-3.7-2.5-5.9-3.2zm-6.8,4.3,2.7-.1-.8,8.2,5.8,5.2-2.1,1.8-6.6-5.9zm-10.5-.7c5.9-4.9,15.4-4.5,21.2.7,5.9,5.3,6,13.6.1,18.4-5.9,4.9-15.4,4.5-21.3-.8-2.1-1.9-3.5-4.1-4-6.4l-3.6-.2,5.7-4.7,5.6,5.1-4.7-.1c.6,1.7,1.6,3.2,3.1,4.6,4.7,4.2,12.4,4.6,17.2.7,4.7-3.9,4.6-10.6,0-14.8-4.6-4.2-12.3-4.5-17.1-.6-1.3,1.1-2.2,2.4-2.8,3.7l-2.2-2c.7-1.4,1.6-2.5,2.9-3.6zm29,7.1,2.9-2.4,2.7,2.5-2.9,2.4zm6-5.2,2.9-2.4,2.7,2.5-2.9,2.4zm-12.9,20.4,2.9-2.5,2.7,2.5-2.9,2.4zm5.9-5.2,2.9-2.4,2.7,2.5-2.9,2.4zm6-5.2,2.9-2.4,2.7,2.5-2.9,2.4zm6-5.2,2.9-2.4,2.7,2.5-2.9,2.4zm-12.9,20.4,2.9-2.4,2.7,2.5-2.9,2.4zm5.9-5.2,2.9-2.4,2.7,2.5-2.9,2.4zm6-5.2,2.9-2.5,2.7,2.5-2.9,2.5zm6-5.2,2.9-2.4,2.7,2.5-2.9,2.4zm-21.2-24.2,5.2,4.6c1.5,1.3-1.2,3.6-2.7,2.3l-5.2-4.6z"/>
+  <text id="name" letter-spacing="-5"><tspan font-weight="900">Queues</tspan></text>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+  <use href="#name" x="137" y="99" style="fill: var(--color-logo-base, #000000); font-family: AvenirN, Arial; font-size: 100px;"/>
+</svg>
+

--- a/static/images/vapor-routingkit.svg
+++ b/static/images/vapor-routingkit.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 607 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @font-face { font-family: AvenirN; font-weight: 900; src: local("Avenir Next Bold"); }
+    @font-face { font-family: AvenirN; font-weight: 400; src: local("Avenir Next Medium"); }
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m29.7,49.8c-7.7-6.2,4.8-15.9,12.5-9.8,7.8,6.2-4.8,15.9-12.5,9.8zm67.2-3.2c-8.2,6.4-20-3-11.8-9.4,8.1-6.4,20,3,11.8,9.4zm-14.6,2.1c.8-.1,2,.9,1.9,1.9l-1,11.1c-.6,2.1-3.7,1.5-3.6-.1l.7-7.4-13.1,10.4c-12.9,10.2-28.3-2.8-15.5-12.9l15.5-12.3c8.3-6.6-1.7-14.3-10.1-7.6l-9.2,7.3c-1.7,1.3-4.1-.5-2.5-1.9l9.2-7.3c11.6-9.1,26.8,2.2,15,11.5l-15.4,12.2c-9.7,7.7,1.4,16.4,10.7,9.1l12.9-10.2-8.9.8c-2.3.2-2.6-3.1-.3-3.3z"/>
+  <text id="name" letter-spacing="-5"><tspan font-weight="900">Routing</tspan><tspan dx="0">Kit</tspan></text>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+  <use href="#name" x="137" y="99" style="fill: var(--color-logo-base, #000000); font-family: AvenirN, Arial; font-size: 100px;"/>
+</svg>
+

--- a/static/images/vapor-sqlitekit.svg
+++ b/static/images/vapor-sqlitekit.svg
@@ -1,0 +1,30 @@
+<svg viewBox="0 0 558 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @font-face { font-family: AvenirN; font-weight: 900; src: local("Avenir Next Bold"); }
+    @font-face { font-family: AvenirN; font-weight: 400; src: local("Avenir Next Medium"); }
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m70.7,24.7v.1l-9.1,7.2-3.9-3.1c-.7-.6-1.9-.6-2.6,0l-12.3,9.7c-.7.6-.8,1.5-.1,2.1l3.9,3.1-9.6,7.6c-1.6,1.2-1.8,2.6-.6,3.5l2.3,1.8,38.7-30.6-2.1-1.7c-1.2-1-3.2-.8-4.6.3zm8.6,2.9-38.8,30.7,16.5,13.2c1,.8,2.3.9,3.5-.1l35.2-27.9c1.3-1,.8-2.1.1-2.7zm-22.9,4.4,2.5,2-9.7,7.7-2.6-2zm22,10.6c0,.1.1,5-.2,7.9-.3,2.8-.5,4-.9,4.9-.2.3-.4.4-.4.4-2.7-.4-5.2-1.4-7.6-2.8-6.2-3.5-6.8-7.2-7-7.1,1.4,5.7,6.6,8.3,9.7,9.4.6.3-2,.8-3.7.4-7.1-1.1-7.8-7.3-7.8-9.1-.1-1.4.2-2.9.4-3.7.1-.2.3-.3.4-.2.6.5,1.8.9,1.8,1,.6.2,1.6.5,1.6.5.9.3,1.2,2.9,1.2,2.9l.5-2.4c6.9,2.5,6.9,8.7,7.5,8.8.9.6,1.9,1.3,2.8,1.9l.3-1.9c.8-3.6,1.1-7.3,1.4-10.9z"/>
+  <text id="name" letter-spacing="-4"><tspan font-weight="900">SQLite</tspan><tspan dx="0">Kit</tspan></text>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+  <use href="#name" x="137" y="99" style="fill: var(--color-logo-base, #000000); font-family: AvenirN, Arial; font-size: 100px;"/>
+</svg>
+

--- a/static/images/vapor-sqlitenio.svg
+++ b/static/images/vapor-sqlitenio.svg
@@ -1,0 +1,29 @@
+<svg viewBox="0 0 620 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @font-face { font-family: AvenirN; font-weight: 900; src: local("Avenir Next Bold"); }
+    @font-face { font-family: AvenirN; font-weight: 400; src: local("Avenir Next Medium"); }
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m81,68c-3.2,3.9-5.9,6.4-8.4,7.8-.9.5-1.5.2-1.5.2-5.7-5.5-10.1-12.2-13.5-19.3-9-18.9-4.2-28.9-4.9-28.9-3,7.7-2.6,16-.4,23.8,1.6,5.3,4.4,10.3,7.8,15.1.4.8-.2.7-.5.5-3.5-1.4-6.6-3.3-9-5.8-15.2-14.7-6.3-30.8-3.5-35.1,2.1-3.4,5.5-6.6,7.3-8.2.5-.4,1.2-.3,1.3.3.6,2.1,2.8,5.2,2.7,5.3.9,1.5,2.9,3.7,3,4,1.7,2.2-2.2,8.9-2.2,8.9l5.2-4.9c7.2,10.1,6.8,19,5.6,25.2-.8,4.1-2.4,8.2-2.1,8.5,1.1,3.1,2.4,6.3,3.5,9.4l3.9-4c8.1-7.4,14.8-15.8,21.7-24-.1.2-8.3,12.2-15.9,21.2z"/>
+  <text id="name" letter-spacing="-4"><tspan font-weight="900">SQLite</tspan><tspan dx="0">NIO</tspan></text>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+  <use href="#name" x="137" y="99" style="fill: var(--color-logo-base, #000000); font-family: AvenirN, Arial; font-size: 100px;"/>
+</svg>

--- a/static/images/vapor-sqlkit.svg
+++ b/static/images/vapor-sqlkit.svg
@@ -1,0 +1,29 @@
+<svg viewBox="0 0 444 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @font-face { font-family: AvenirN; font-weight: 900; src: local("Avenir Next Bold"); }
+    @font-face { font-family: AvenirN; font-weight: 400; src: local("Avenir Next Medium"); }
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m61.7,47.7c4.7-1.8,10.4-6.5,12.6-10.3,2.7-4.6-1.1-3.6-4-2.4l1.3-2c.4-.1,3.1-.8,4.4.3l17.3,14.6c1.3,1.1.3,3.9-.3,4.9-2.2,4.3-8,9.5-13,11.6-1.3.5-4.6,1.6-5.9.4l-17.6-15.6c-1.7-1.6-.4-5.3,4.4-9.7.7,0,1.3.2,1.9.4-5.1,4.5-8.4,10.7-1.1,7.8zm-12.2-8.6,4.6.3-1,21.8c-.1,2.7-5,2.5-4.8-.3zm12-12.1,1.9-.6,3.1,8.3zm9.4-.5,2,.7-4.6,7.4zm-21.9,5.8,5.7.3c.1,0,.3.1.3.3l-.1.6c6.3.9,11.6,3.5,15,6.9-4.3-1.8-9.4-3.1-15.1-3.7v1.5c0,.2-.1.3-.4.2l-5.6-.2c-.2,0-.4-.2-.4-.4l.1-1.4c-5.7,0-11,.8-15.6,2.2,3.8-3.2,9.4-5.2,15.8-5.5l.1-.5c0-.3.2-.3.2-.3zm38.9,17.7c.5-.4,1.4-.3,2,.1.5.5.5,1.2,0,1.7-.5.4-1.3.4-1.8-.1-.7-.5-.7-1.2-.2-1.7zm-5.6-4.8c.4-.4,1.3-.4,1.9.1.5.4.5,1.1.1,1.6-.6.5-1.4.4-2-.1-.5-.4-.6-1.2,0-1.6zm-5.9-5c.5-.5,1.4-.4,1.9.1.6.4.6,1.2.1,1.5-.6.5-1.4.5-1.9,0-.6-.4-.6-1.1-.1-1.6zm11.7,5.4c-.7,5-10.5,13.7-16.8,14.6l3.9,3.5c2.4,1.3,12.9-5.1,16.3-11.6.5-1.2,1.4-2.5,0-3.7zm-18.6,12.9c2.4,1.4,12.8-4.9,16.3-11.3.8-1.6,1.1-2.8.4-3.2l-3.7-3.2c-.8,4.9-10.6,13.5-16.9,14.3zm-5.7-5.1c2.4,1.4,12.8-4.6,16.3-11,.9-1.6,1.1-2.8.6-3.2l-3.9-3.3c-1,4.9-10.9,13.2-17.1,14z"/>
+  <text id="name" letter-spacing="-4"><tspan font-weight="900">SQL</tspan><tspan dx="0">Kit</tspan></text>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+  <use href="#name" x="137" y="99" style="fill: var(--color-logo-base, #000000); font-family: AvenirN, Arial; font-size: 100px;"/>
+</svg>

--- a/static/images/vapor-websocketkit.svg
+++ b/static/images/vapor-websocketkit.svg
@@ -1,0 +1,29 @@
+<svg viewBox="0 0 759 128" xmlns="http://www.w3.org/2000/svg" id="technology">
+  <defs>
+  <style>
+    @font-face { font-family: AvenirN; font-weight: 900; src: local("Avenir Next Bold"); }
+    @font-face { font-family: AvenirN; font-weight: 400; src: local("Avenir Next Medium"); }
+    @media(prefers-color-scheme: dark) {
+      :root { --color-logo-shape: #000000; --color-logo-base: #ffffff; }
+    }
+    body[data-color-scheme="dark"] {
+      --color-logo-shape: #000000; --color-logo-base: #ffffff;
+    }
+  </style>
+  <path id="surface" d="m 6,47 l 58,-47 58,47 -58,45 z"/>
+  <path id="strut"   d="m 6,47 v 12 l 58,45 v -12 z"/>
+  <path id="shape"   d="m81.2,47.83,6.24-3.6-8.65-15-11.1-2.97-1.86,6.96,8.2,2.2zm8.06-.5-21.76,12.56-8.2-2.2.93-3.5,6.8,1.8,8.84-5.1-13.74-3.7.94-3.5,13.73,3.7-5.1-8.84-6.75-1.8.93-3.45-17.1-4.6-21.73,12.55,9.8,2.63,12.9-7.43,7.2,1.93-2.8,10.5-7.2-1.93-2.04-3.54-6.24,3.6,3.53,6.1,17.03,4.56-1.86,6.93,11.1,2.97,30.6-17.67z"/>
+  <text id="name" letter-spacing="-5"><tspan font-weight="900">Websocket</tspan><tspan dx="2">Kit</tspan></text>
+  </defs>
+  <use href="#strut" fill="#9ee0ff"/>
+  <use href="#strut" fill="#6bd0ff" y="12"/>
+  <use href="#strut" fill="#38c0ff" y="24"/>
+  <g transform="matrix(-1 0 0 1 128 0)">
+    <use href="#strut" fill="#f29eff"/>
+    <use href="#strut" fill="#eb6bff" y="12"/>
+    <use href="#strut" fill="#e438ff" y="24"/>
+  </g>
+  <use href="#surface" style="fill: var(--color-logo-base, #000000);"/>
+  <use href="#shape" style="fill: var(--color-logo-shape, #ffffff);"/>
+  <use href="#name" x="137" y="99" style="fill: var(--color-logo-base, #000000); font-family: AvenirN, Arial; font-size: 100px;"/>
+</svg>


### PR DESCRIPTION
Banners do not exist yet for `apns`, `email`, `queues-redis-driver`, or `redis`. Banners have been omitted for `vapor`, which uses a different banner design; `fluent-mongo-driver`, which is deprecated; and `async-kit`, for which a banner exists but currently does not render correctly.

Also fixes a typo in the "Swift 6.0+" badge and adds badges for 6.1 and 6.2 while we're at it.