### PR TITLE
Unify Syntax Highlighting

### DIFF
--- a/src/scss/docs.scss
+++ b/src/scss/docs.scss
@@ -4,5 +4,6 @@
 // (docs.vapor.codes, api.vapor.codes) — NOT the marketing sites, which load only
 // main.css. Both partials style Kiln's `.kiln-*` / `.docc-*` markup and lean on
 // the `--vp-*` design tokens defined in main.css.
+@import "vapor/colors";
 @import "docs/layout";
 @import "docs/docc";

--- a/src/scss/docs/_docc.scss
+++ b/src/scss/docs/_docc.scss
@@ -10,17 +10,23 @@
  * intended to be extracted into the shared Vapor design system in Milestone 2.
  */
 
+// Syntax colours mirror the highlight.js code-block palette (vapor.scss) so DocC
+// declarations and prose code use identical colours. Keep in sync with syntax.scss.
 :root {
     --docc-decl-bg: var(--vp-grey-100);
-    --docc-keyword: #ad3da4;
-    --docc-type: #3900a0;
+    --docc-keyword: #701980; // $pink-500
+    --docc-type: #135b80;    // $blue-500
+    --docc-string: #b11fcc;  // $pink-400
+    --docc-number: #1b6fb3;  // $code-title-light
     --docc-param: var(--vp-grey-800);
 }
 
 html.dark {
     --docc-decl-bg: #1c1c1f;
-    --docc-keyword: #ff7ab2;
-    --docc-type: #6bdfff;
+    --docc-keyword: #ea7efc; // $pink-200
+    --docc-type: #a6e3ff;    // $blue-200
+    --docc-string: #f9ecfb;  // $pink-100
+    --docc-number: #40c4ff;  // $blue-300
     --docc-param: var(--vp-grey-300);
 }
 
@@ -90,9 +96,9 @@ a.token-typeIdentifier:hover { text-decoration: underline; }
 .token-externalParam { color: var(--vp-text); font-weight: 600; }
 .token-internalParam,
 .token-genericParameter { color: var(--vp-text-muted); }
-.token-text,
-.token-number,
-.token-string { color: var(--vp-text); }
+.token-text { color: var(--vp-text); }
+.token-number { color: var(--docc-number); }
+.token-string { color: var(--docc-string); }
 
 /* ---- Parameters / possible values ---- */
 

--- a/src/scss/docs/_docc.scss
+++ b/src/scss/docs/_docc.scss
@@ -10,23 +10,23 @@
  * intended to be extracted into the shared Vapor design system in Milestone 2.
  */
 
-// Syntax colours mirror the highlight.js code-block palette (vapor.scss) so DocC
-// declarations and prose code use identical colours. Keep in sync with syntax.scss.
+// Syntax colours reuse the shared palette (vapor/_colors.scss) so DocC
+// declarations and highlight.js code blocks stay identical.
 :root {
     --docc-decl-bg: var(--vp-grey-100);
-    --docc-keyword: #701980; // $pink-500
-    --docc-type: #135b80;    // $blue-500
-    --docc-string: #b11fcc;  // $pink-400
-    --docc-number: #1b6fb3;  // $code-title-light
+    --docc-keyword: #{$pink-500};
+    --docc-type: #{$blue-500};
+    --docc-string: #{$pink-400};
+    --docc-number: #{$code-title-light};
     --docc-param: var(--vp-grey-800);
 }
 
 html.dark {
-    --docc-decl-bg: #1c1c1f;
-    --docc-keyword: #ea7efc; // $pink-200
-    --docc-type: #a6e3ff;    // $blue-200
-    --docc-string: #f9ecfb;  // $pink-100
-    --docc-number: #40c4ff;  // $blue-300
+    --docc-decl-bg: var(--vp-off-black);
+    --docc-keyword: #{$pink-200};
+    --docc-type: #{$blue-200};
+    --docc-string: #{$pink-100};
+    --docc-number: #{$blue-300};
     --docc-param: var(--vp-grey-300);
 }
 

--- a/src/scss/vapor/_colors.scss
+++ b/src/scss/vapor/_colors.scss
@@ -1,0 +1,72 @@
+// Shared colour palette — variables only, emits no CSS. Imported by the main
+// bundle (vapor.scss) and the docs bundle (docs.scss) so both draw syntax and
+// theme colours from one source (e.g. the DocC declaration tokens in _docc.scss
+// reuse the same $pink-*/$blue-* values as the highlight.js code blocks).
+$blue-500: #135b80;
+$blue-400: #1e92cc;
+$blue-300: #40c4ff;
+$blue-200: #a6e3ff;
+$blue-100: #e8f6fd;
+$pink-500: #701980;
+$pink-400: #b11fcc;
+$pink-300: #df3efb;
+$pink-200: #ea7efc;
+$pink-100: #f9ecfb;
+$grey-900: #141416;
+$grey-800: #373953;
+$grey-700: #666880;
+$grey-600: #8385a3;
+$grey-500: #9fa1bf;
+$grey-400: #c1c2d6;
+$grey-300: #dfe0eb;
+$grey-200: #f0f0f7;
+$grey-100: #fafafd;
+$off-black: #1c1c1f;
+$off-light-grey: #eaecf0;
+$off-black-2: #101828;
+// these colours are used in the code error blocks on the main page
+$code-error-sidebar-background-red: #b2235f1a;
+$code-explainer-title: #df3feb;
+$code-error-background: rgba(179, 35, 95, 0.21);
+// Light-purple border tint shared by the code blocks (syntax, dark mode) and
+// the code-error box — defined once so the rgb isn't repeated across files.
+$code-border-purple: #ddd6fe;
+$code-error-border: rgba($code-border-purple, 0.1);
+// Dark-mode code-error red (the sidebar/background tints in vapor-dark).
+$code-error-red: #801944;
+// these colours are used in code blocks
+$variable-blue: #3f6e74;
+$code-text-blue: #8194f7;
+$code-link-blue: #6699ff;
+$code-section-heading-red: #643820;
+$code-substring: #000;
+// Light-mode syntax token colours. The vibrant tokens above read fine on the
+// dark code background but fail WCAG AA on the near-white light code bg
+// (1.9–3.4:1). These darker, hue-preserving variants apply in light mode; the
+// `.dark` block restores the vibrant colours. (Tokens already dark enough —
+// string $pink-400, type $blue-500, attr $pink-500, variable — are unchanged.)
+$code-text-light: #3b3f8f;   // base text / operators (was #8194f7, 2.7:1 → 8.9:1)
+$code-title-light: #1b6fb3;  // titles / numbers (was #40c4ff, 1.9:1 → 5.2:1)
+$code-link-light: #2f54d4;   // regexp / links (was #6699ff, 2.7:1 → 6.1:1)
+$code-formula: #eee;
+$code-addition: #baeeba;
+$code-deletion: #ffc8bd;
+// Diff line text. The base code text (#8194f7) is far too light on the pale
+// add/remove backgrounds (≈2:1), so diff lines get their own readable text
+// colour per mode (all ≥7:1 vs their background — WCAG AA/AAA).
+// Light mode: dark green / dark red text on the pale bands.
+$code-addition-text: #0f5132;
+$code-deletion-text: #842029;
+// Dark mode: subtle dark green / red tinted bands (layered over the dark code
+// background) with light green / red text — keeps the git add/remove theme.
+$code-addition-dark-bg: rgba(63, 185, 80, 0.18);
+$code-deletion-dark-bg: rgba(248, 81, 73, 0.18);
+$code-addition-dark-text: #7ee787;
+$code-deletion-dark-text: #ffa198;
+$code-selector: #9b703f;
+// Bright blue for the code-block radial glow (syntax) and the main-site brand
+// "blurry-background" gradient.
+$gradient-blue: #23acf0;
+// Decorative "code outline" gradient on the main-site features section.
+$code-outline-grey: #94a8b2;
+$code-outline-light: #f6f7f7;

--- a/src/scss/vapor/vapor.scss
+++ b/src/scss/vapor/vapor.scss
@@ -9,74 +9,8 @@
 // The old $custom-colors -> $theme-colors map-merge was also removed: it only
 // generated unused .text-grey-* / .bg-grey-* / --bs-grey-* utility classes (the
 // $grey-*/$blue-*/$pink-* Sass variables below are what's actually used).
-$blue-500: #135b80;
-$blue-400: #1e92cc;
-$blue-300: #40c4ff;
-$blue-200: #a6e3ff;
-$blue-100: #e8f6fd;
-$pink-500: #701980;
-$pink-400: #b11fcc;
-$pink-300: #df3efb;
-$pink-200: #ea7efc;
-$pink-100: #f9ecfb;
-$grey-900: #141416;
-$grey-800: #373953;
-$grey-700: #666880;
-$grey-600: #8385a3;
-$grey-500: #9fa1bf;
-$grey-400: #c1c2d6;
-$grey-300: #dfe0eb;
-$grey-200: #f0f0f7;
-$grey-100: #fafafd;
-$off-black: #1c1c1f;
-$off-light-grey: #eaecf0;
-$off-black-2: #101828;
-// these colours are used in the code error blocks on the main page
-$code-error-sidebar-background-red: #b2235f1a;
-$code-explainer-title: #df3feb;
-$code-error-background: rgba(179, 35, 95, 0.21);
-// Light-purple border tint shared by the code blocks (syntax, dark mode) and
-// the code-error box — defined once so the rgb isn't repeated across files.
-$code-border-purple: #ddd6fe;
-$code-error-border: rgba($code-border-purple, 0.1);
-// Dark-mode code-error red (the sidebar/background tints in vapor-dark).
-$code-error-red: #801944;
-// these colours are used in code blocks
-$variable-blue: #3f6e74;
-$code-text-blue: #8194f7;
-$code-link-blue: #6699ff;
-$code-section-heading-red: #643820;
-$code-substring: #000;
-// Light-mode syntax token colours. The vibrant tokens above read fine on the
-// dark code background but fail WCAG AA on the near-white light code bg
-// (1.9–3.4:1). These darker, hue-preserving variants apply in light mode; the
-// `.dark` block restores the vibrant colours. (Tokens already dark enough —
-// string $pink-400, type $blue-500, attr $pink-500, variable — are unchanged.)
-$code-text-light: #3b3f8f;   // base text / operators (was #8194f7, 2.7:1 → 8.9:1)
-$code-title-light: #1b6fb3;  // titles / numbers (was #40c4ff, 1.9:1 → 5.2:1)
-$code-link-light: #2f54d4;   // regexp / links (was #6699ff, 2.7:1 → 6.1:1)
-$code-formula: #eee;
-$code-addition: #baeeba;
-$code-deletion: #ffc8bd;
-// Diff line text. The base code text (#8194f7) is far too light on the pale
-// add/remove backgrounds (≈2:1), so diff lines get their own readable text
-// colour per mode (all ≥7:1 vs their background — WCAG AA/AAA).
-// Light mode: dark green / dark red text on the pale bands.
-$code-addition-text: #0f5132;
-$code-deletion-text: #842029;
-// Dark mode: subtle dark green / red tinted bands (layered over the dark code
-// background) with light green / red text — keeps the git add/remove theme.
-$code-addition-dark-bg: rgba(63, 185, 80, 0.18);
-$code-deletion-dark-bg: rgba(248, 81, 73, 0.18);
-$code-addition-dark-text: #7ee787;
-$code-deletion-dark-text: #ffa198;
-$code-selector: #9b703f;
-// Bright blue for the code-block radial glow (syntax) and the main-site brand
-// "blurry-background" gradient.
-$gradient-blue: #23acf0;
-// Decorative "code outline" gradient on the main-site features section.
-$code-outline-grey: #94a8b2;
-$code-outline-light: #f6f7f7;
+// Colour palette — extracted so the docs bundle (docs.scss) can share it too.
+@import "colors";
 
 // Define the fonts:
 // IBM Plex Sans Arabic leads the stack but is restricted to Arabic codepoints


### PR DESCRIPTION
Extract out the colours so that the DocC highlighting (which is different to regular code blocks) matches the rest of our design
